### PR TITLE
Fix settings openai api key optional

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -7,7 +7,7 @@ class Settings(BaseSettings):
     """Конфигурация приложения"""
 
     # OpenAI Configuration
-    openai_api_key: str
+    openai_api_key: Optional[str] = None
     openai_model: str = "gpt-3.5-turbo"
     openai_temperature: float = 0
 


### PR DESCRIPTION
## Summary
- make `openai_api_key` optional so settings can load without env

## Testing
- `pip install -q -r backend/requirements.txt -r telegram-bot/requirements.txt`
- `pytest -q` *(fails: Query execution failed; many tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_686cb34c78c0832f8ce9ea15b80764ae